### PR TITLE
Update Cargo.toml

### DIFF
--- a/kradical_parsing/Cargo.toml
+++ b/kradical_parsing/Cargo.toml
@@ -11,6 +11,6 @@ categories = ["parsing"]
 [dependencies]
 thiserror = "1"
 nom = "6"
-encoding = "0"
+encoding = "0.2"
 unicode-segmentation = "1"
 kradical_jis = "0.1.0"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.